### PR TITLE
Remove Support for Tix

### DIFF
--- a/tkinterdnd2/TkinterDnD.py
+++ b/tkinterdnd2/TkinterDnD.py
@@ -23,12 +23,7 @@ tkinter.Tk() window. This will add the drag-and-drop specific methods to the
 Tk window and all its descendants.
 '''
 
-try:
-    import Tkinter as tkinter
-    import Tix as tix
-except ImportError:
-    import tkinter
-    from tkinter import tix
+import tkinter
 
 TkdndVersion = None
 
@@ -282,11 +277,4 @@ class Tk(tkinter.Tk, DnDWrapper):
     DnDWrapper class apply to this window and all its descendants.'''
     def __init__(self, *args, **kw):
         tkinter.Tk.__init__(self, *args, **kw)
-        self.TkdndVersion = _require(self)
-
-class TixTk(tix.Tk, DnDWrapper):
-    '''Creates a new instance of a tix.Tk() window; all methods of the
-    DnDWrapper class apply to this window and all its descendants.'''
-    def __init__(self, *args, **kw):
-        tix.Tk.__init__(self, *args, **kw)
         self.TkdndVersion = _require(self)

--- a/tkinterdnd2/__init__.py
+++ b/tkinterdnd2/__init__.py
@@ -20,6 +20,5 @@ FileGroupDescriptorW = 'FileGroupDescriptorW - FileContents'# ??
 
 from . import TkinterDnD
 from .TkinterDnD import Tk
-from .TkinterDnD import TixTk
 
 


### PR DESCRIPTION
Tix was depreciated in Python 3.6 and removed in Python3.13. 

In the original code, it would default to importing Tix and if it could not, it would attempt to import tix from tkinter. Instead, we just load tkinter. Further, we no longer create a TixTk class as it is no longer needed. Tix has been unsupported for 10 years. All functionality provided by Tix now exists within `tkinter` and `ttk`. Window creation now belongs to fully to tkinter we do not need the other class anymore.

Change was tested locally using both python3.10 and python3.13. Change appears to be working as expected.